### PR TITLE
Make the classes pass most of the puppet-lint checks

### DIFF
--- a/class-base.pp
+++ b/class-base.pp
@@ -1,22 +1,22 @@
 class base {
-	
-	package { 'sudo':
-		ensure => latest
-	}
 
-	file { 'sudoers':
-		path	=>	'/etc/sudoers',
-		ensure	=>	file,
-		require	=>	Package['sudo'],
-		source	=>	'/etc/sudoers'
-	}
+  package { 'sudo':
+    ensure => latest
+  }
 
-	package { "zsh":
-		ensure	=>	latest
-	}
+  file { 'sudoers':
+    ensure  => file,
+    path    => '/etc/sudoers',
+    require => Package['sudo'],
+    source  => '/etc/sudoers'
+  }
 
-	package { "tcsh":
-		ensure	=>	latest
-	}
+  package { 'zsh':
+    ensure => latest
+  }
+
+  package { 'tcsh':
+    ensure => latest
+  }
 
 }

--- a/class-nginx.pp
+++ b/class-nginx.pp
@@ -1,27 +1,27 @@
 class nginx  {
-	yumrepo { "nginx":
-		baseurl => 	'http://nginx.org/packages/centos/6/x86_64/',
-		descr   =>	'nginx',
-		enabled =>	1,
-		gpgcheck =>	0
-	}
+  yumrepo { 'nginx':
+    baseurl  => 'http://nginx.org/packages/centos/6/x86_64/',
+    descr    => 'nginx',
+    enabled  => 1,
+    gpgcheck => 0
+  }
 
-	package { "nginx":
-		ensure	=>	latest
-	}
+  package { 'nginx':
+    ensure => latest
+  }
 
-	file { 'nginx.conf':
-		path	=>	'/etc/nginx/nginx.conf',
-		ensure	=>	file,
-		require	=> Package['nginx'],
-		source	=>	'/root/puppet-manifests/resource/nginx.conf'
-	}
-	service { 'nginx':
-		name	=>	'nginx',
-		ensure	=>	running,
-		enable	=>	true,
-		subscribe => File['nginx.conf']
-	}
+  file { 'nginx.conf':
+    ensure  => file,
+    path    => '/etc/nginx/nginx.conf',
+    require => Package['nginx'],
+    source  => '/root/puppet-manifests/resource/nginx.conf'
+  }
+  service { 'nginx':
+    ensure    => running,
+    name      => 'nginx',
+    enable    => true,
+    subscribe => File['nginx.conf']
+  }
 
 }
 

--- a/class-redis.pp
+++ b/class-redis.pp
@@ -1,7 +1,7 @@
 class redis  {
 
-	package { "redis":
-		ensure	=>	latest
-	}
+  package { 'redis':
+    ensure  =>  latest
+  }
 
 }

--- a/class-vsftpd.pp
+++ b/class-vsftpd.pp
@@ -1,21 +1,21 @@
 class vsftpd {
 
-	package { "vsftpd":
-		ensure	=>	latest
-	}
+  package { 'vsftpd':
+    ensure => latest
+  }
 
-	file { 'vsftpd.conf':
-		path	=>	'/etc/vsftpd/vsftpd.conf',
-		ensure	=>	file,
-		require	=> Package['vsftpd'],
-		source	=>	'/root/puppet-manifests/resource/vsftpd.conf'
-	}
+  file { 'vsftpd.conf':
+    ensure  => file,
+    path    => '/etc/vsftpd/vsftpd.conf',
+    require => Package['vsftpd'],
+    source  => '/root/puppet-manifests/resource/vsftpd.conf'
+  }
 
-	service { 'vsftpd':
-		name	=>	'vsftpd',
-		ensure	=>	running,
-		enable	=>	true,
-		subscribe => File['vsftpd.conf']
-	}
+  service { 'vsftpd':
+    ensure    => running,
+    name      => 'vsftpd',
+    enable    => true,
+    subscribe => File['vsftpd.conf']
+  }
 
 }

--- a/site.pp
+++ b/site.pp
@@ -1,9 +1,12 @@
 #Make sure sudoers is has the right owner/mode
-file { "/etc/sudoers":
-	owner => root, group => root, mode => 400
+file { '/etc/sudoers':
+  owner => 'root',
+  group => 'root',
+  mode  => '0400'
 }
+
 #Purge existing Puppet firewall rules
-resources { "firewall":
+resources { 'firewall':
   purge => true
 }
 

--- a/users.pp
+++ b/users.pp
@@ -1,34 +1,34 @@
-user { 'tanner':  
-	ensure => 'present',
-	groups => ['wheel'],
-	home => '/home/tanner',
-	shell => '/bin/zsh'
+user { 'tanner':
+  ensure => 'present',
+  groups => ['wheel'],
+  home   => '/home/tanner',
+  shell  => '/bin/zsh'
 }
 
 user { 'yousef':
-	ensure => 'present',
-	groups => ['wheel'],
-	home => '/home/yousef',
-	shell => '/bin/bash'
+  ensure => 'present',
+  groups => ['wheel'],
+  home   => '/home/yousef',
+  shell  => '/bin/bash'
 }
 
 user { 'tom':
-	ensure => 'present',
-	groups => ['wheel'],
-	home => '/home/tom',
-	shell => '/bin/zsh'
+  ensure => 'present',
+  groups => ['wheel'],
+  home   => '/home/tom',
+  shell  => '/bin/zsh'
 }
 
 user { 'mrz':
-	ensure => 'present',
-	groups => ['wheel'],
-	home => '/home/mrz',
-	shell => '/bin/tcsh'
+  ensure => 'present',
+  groups => ['wheel'],
+  home   => '/home/mrz',
+  shell  => '/bin/tcsh'
 }
 
 user { 'ewong':
-	ensure => 'present',
-	groups => ['wheel'],
-	home => '/home/ewong',
-	shell => '/bin/bash'
+  ensure => 'present',
+  groups => ['wheel'],
+  home   => '/home/ewong',
+  shell  => '/bin/bash'
 }


### PR DESCRIPTION
I've done a basic puppet-lint --with-filename *.pp run and a tidy up of the issues it raises. If you don't have an explicit set of local puppet coding styles then the puppet-lint ones (which are derived from the Puppetlabs wiki) are a handy common set of short cuts to ensure the codebase stays consistent.

This also changes tabs to spaces so it might be even more contentious. I have no issues with this not being applied, I just wanted to show one of the options.
