### PR TITLE
Postfix module

### DIFF
--- a/modules/postfix/manifests/init.pp
+++ b/modules/postfix/manifests/init.pp
@@ -10,7 +10,7 @@ class { 'postfix':
     'smtp_sasl_password_maps = hash:/etc/postfix/sasl/passwd',
     'smtp_sasl_security_options = noanonymous',
     'smtp_use_tls = yes',
-    'relayhost = [smtp.mandrillapp.com'],
+    'relayhost = [smtp.mandrillapp.com]'],
     ensure => 'present'
   }
 }


### PR DESCRIPTION
Using http://help.mandrill.com/entries/23060367-Can-I-configure-Postfix-to-send-through-Mandrill- as docs, it should configure the postfix settings to send through smtp.
